### PR TITLE
articles.link 컬럼에 "localhost"가 담긴 레코드를 필터링하는 전역 모델 스코프 추가

### DIFF
--- a/app/Entities/Article.php
+++ b/app/Entities/Article.php
@@ -2,13 +2,20 @@
 
 namespace App\Entities;
 
-use Illuminate\Support\Facades\Log;
+use App\Scopes\FilterLocalhost;
 use Prettus\Repository\Contracts\Transformable;
 use Prettus\Repository\Traits\TransformableTrait;
 
 class Article extends \ModernPUG\FeedReader\Article implements Transformable
 {
     use TransformableTrait;
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope(new FilterLocalhost);
+    }
 
     public function tags()
     {

--- a/app/Scopes/FilterLocalhost.php
+++ b/app/Scopes/FilterLocalhost.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\ScopeInterface;
+
+class FilterLocalhost implements ScopeInterface
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $builder
+     * @param  \Illuminate\Database\Eloquent\Model $model
+     * @return void
+     */
+    public function apply(Builder $builder, Model $model)
+    {
+        $builder->where('link', 'NOT LIKE', '%localhost%');
+    }
+
+    /**
+     * Remove the scope from the given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $builder
+     * @param  \Illuminate\Database\Eloquent\Model $model
+     *
+     * @return void
+     */
+    public function remove(Builder $builder, Model $model)
+    {
+        // TODO: Implement remove() method.
+    }
+}


### PR DESCRIPTION
@koojunho @smartbos 

제가 싼 똥 치웁니다. 

블로그에서 Jekyll을 사용하는데, 제가 직접 만든 피드가 있었고, jekyll-feed라는 플러그인이 만든 피드, 해서 전부 두 개가 있었나 봅니다. jekyll-feed가 블로그 작성 중에 만든 feed.xml이 localhost:4000을 만들고, 퍼블리시 할 때 두 개가 모두 올라간 것으로 추정합니다.

여튼 전역 스코프를 추가해서 `articles.link`에 `localhost`를 포함하고 있으면 쿼리에서 제외하도록 하였습니다. 검토하시고 머지되면 배포해주세요.

고맙습니다.